### PR TITLE
Fix defaultProps typo

### DIFF
--- a/src/components/InputField.js
+++ b/src/components/InputField.js
@@ -131,7 +131,7 @@ InputField.defaultProps = {
     maxlength:30,
     pattern:undefined,
     autocomplete:'off',
-    requierd:false,
+    required:false,
     disabled:false,
     placeholder:undefined,
     error:'This field is required',


### PR DESCRIPTION
## Summary
- correct `requierd` typo in `InputField` default props

## Testing
- `npm install` *(fails: unable to reach registry)*

------
https://chatgpt.com/codex/tasks/task_e_68864c9552ac83259faf59dc611cbb28