### PR TITLE
Add InputField component test

### DIFF
--- a/src/components/__tests__/InputField.test.js
+++ b/src/components/__tests__/InputField.test.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import InputField from '../InputField';
+
+function Wrapper({onChange}) {
+  const [value, setValue] = React.useState('');
+  const handleChange = val => {
+    if (onChange) {
+      onChange(val);
+    }
+    setValue(val);
+  };
+  return <InputField value={value} change={handleChange} />;
+}
+
+test('InputField default props change event updates value', () => {
+  const changeSpy = jest.fn();
+  const { getByRole } = render(<Wrapper onChange={changeSpy} />);
+  const input = getByRole('textbox');
+  fireEvent.change(input, { target: { value: 'abc' } });
+  expect(changeSpy).toHaveBeenCalledWith('abc');
+  expect(input.value).toBe('abc');
+});


### PR DESCRIPTION
## Summary
- add tests for `InputField` default behaviour

## Testing
- `yarn test --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6886513aac488325bc9973b7eb01ccf4