### PR TITLE
Fix typo 'costum classes' in documentation

### DIFF
--- a/src/views/ButtonPage.js
+++ b/src/views/ButtonPage.js
@@ -256,7 +256,7 @@ class ButtonPage extends React.Component{
                             <p><span className="bold prop">size:</span> Determine btn size - Small / Medium / Large | string (lowercase)</p>
                             <p><span className="bold prop">click:</span> A function from parent that will fired on click of the button | function </p>
                             <p><span className="bold prop">loading:</span> An option to show to user that a process that needs to be done is happening in the background | boolean</p>
-                            <p><span className="bold prop">classes:</span> costum classes that can be added to the component | string </p>
+                            <p><span className="bold prop">classes:</span> custom classes that can be added to the component | string </p>
                             <p><span className="bold prop">theme:</span> Primary / Secondary / third | string (lowercase)</p>
                             <p><span className="bold prop">id: </span>Special id for element cathing with js | string </p>
                             <p><span className="bold prop">rounded:</span> Rounded button angles - done</p>

--- a/src/views/CheckboxPage.js
+++ b/src/views/CheckboxPage.js
@@ -167,7 +167,7 @@ class CheckboxPage extends React.Component{
                             <p><span className="bold prop">label:</span> The text that will be written aside the radio button | string</p>
                             <p><span className="bold prop">name:</span> This value is for checkbox value for submit | string </p>
                             <p><span className="bold prop">value:</span> The value that will be transfer as the user selection when click on this option | string </p>
-                            <p><span className="bold prop">classes:</span> costum classes that can be added to the component | string </p>
+                            <p><span className="bold prop">classes:</span> custom classes that can be added to the component | string </p>
                             <p><span className="bold prop">id:</span> Special id for element cathing with js | string </p>
                             <p><span className="bold prop">isChecked:</span> Set the radio button state - chosen ir not | boolean</p>
                             <p><span className="bold prop">disabled:</span> Option of disable the radio button | boolean</p>

--- a/src/views/FormPage.js
+++ b/src/views/FormPage.js
@@ -234,7 +234,7 @@ class FormPage extends React.Component{
                             <h2>Component props</h2>
                             <p><span className="bold prop">title:</span> The title of the form | string</p>
                             <p><span className="bold prop">id:</span> Special id for element cathing with js | string </p>
-                            <p><span className="bold prop">classes:</span> costum classes that can be added to the component | string </p>
+                            <p><span className="bold prop">classes:</span> custom classes that can be added to the component | string </p>
                             <p><span className="bold prop">onSubmit:</span> A function from parent that will occur when the form submit | function </p>
                             <p><span className="bold prop">novalidate:</span> Determine if the form will be validate | boolean </p>
                             <p><span className="bold prop">error:</span> A general error in case of an invalid field value | string </p>

--- a/src/views/IconPage.js
+++ b/src/views/IconPage.js
@@ -164,7 +164,7 @@ class IconPage extends React.Component{
                         <div className="col-1 props-keys">
                             {/* props options */}
                             <h2>Component props </h2>
-                            <p><span className="bold prop">classes:</span> costum classes that can be added to the component | string </p>
+                            <p><span className="bold prop">classes:</span> custom classes that can be added to the component | string </p>
                             <p><span className="bold prop">icon-class:</span> class from <a href="https://semantic-ui.com/elements/icon.html" target="_blank" rel="noopener noreferrer" className="link emphasis emphasis-color">ui-semantic</a> that 'create' the desired icon | string </p>
                             <p><span className="bold prop">click:</span> A function from parent that will fired on click of the icon | arrow function </p>
                         </div>

--- a/src/views/ImgPage.js
+++ b/src/views/ImgPage.js
@@ -109,7 +109,7 @@ class ImgPage extends React.Component{
                             <p><span className="bold prop">alt:</span> Altrnative text in some case the element doesn't load to page | string </p>
                             <p><span className="bold prop">width:</span> Width size of the image in the page | string </p>
                             <p><span className="bold prop">height:</span> Height size of the image in the page | string </p>
-                            <p><span className="bold prop">classes:</span> costum classes that can be added to the component | string </p>
+                            <p><span className="bold prop">classes:</span> custom classes that can be added to the component | string </p>
                             <p><span className="bold prop">click:</span> A function from parent that will occur when the user click on the image | function </p>
                         </div>                    
                     </div>

--- a/src/views/InputFieldPage.js
+++ b/src/views/InputFieldPage.js
@@ -447,7 +447,7 @@ class InputFieldPage extends React.Component{
                             <p><span className="bold prop">label: </span>The text that will be written aside the Input field | string</p>
                             <p><span className="bold prop">type: </span>Options of input types - Text, Number, Email, Password, Telephone | string</p>
                             <p><span className="bold prop">id: </span>Special id for element cathing with js | string </p>
-                            <p><span className="bold prop">classes: </span>costum classes that can be added to the component | string </p>
+                            <p><span className="bold prop">classes: </span>custom classes that can be added to the component | string </p>
                             <p><span className="bold prop">name: </span>This value is for all the radio buttons belongs to the same group | string </p>
                             <p><span className="bold prop">min: </span>for input with numbers type. set the minimum value for the user input | number / string</p>
                             <p><span className="bold prop">max: </span>for input with numbers type. set the maximum value for the user input | number / string</p>

--- a/src/views/ModalPage.js
+++ b/src/views/ModalPage.js
@@ -114,7 +114,7 @@ class ModalPage extends React.Component{
                             <p><span className="bold prop">modalTitle:</span> The header title of the modal | string</p>
                             <p><span className="bold prop">heroImage:</span> Makes the modal header with hero image | string (of the src)</p>
                             <p><span className="bold prop">closeButton:</span> An option to create a modal without close option | boolean </p>
-                            <p><span className="bold prop">classes:</span> costum classes that can be added to the component | string </p>
+                            <p><span className="bold prop">classes:</span> custom classes that can be added to the component | string </p>
                         </div>
                     </div>
 

--- a/src/views/RadioPage.js
+++ b/src/views/RadioPage.js
@@ -174,7 +174,7 @@ class RadioPage extends React.Component{
                             <p><span className="bold prop">name:</span> This value is for all the radio buttons belongs to the same group | string </p>
                             <p><span className="bold prop">val:</span> The value that will be transfer as the user selection when click on this option | string </p>
                             <p><span className="bold prop">id: </span>Special id for element cathing with js | string </p>
-                            <p><span className="bold prop">classes:</span> costum classes that can be added to the component | string </p>
+                            <p><span className="bold prop">classes:</span> custom classes that can be added to the component | string </p>
                             <p><span className="bold prop">disabled:</span> Option of disable the button | boolean</p>
                             <p><span className="bold prop">isSelected:</span> Set the radio button state - chosen ir not | boolean</p>
                             <p><span className="bold prop">type:</span> Determine if the type of button will look as press button - pressButton | string </p>

--- a/src/views/SelectFieldPage.js
+++ b/src/views/SelectFieldPage.js
@@ -128,7 +128,7 @@ class SelectFieldPage extends React.Component {
                             <p><span className="bold prop">label:</span> The text that will be written aside the Input field | string</p>
                             <p><span className="bold prop">id:</span> Special id for element cathing with js | string </p>
                             <p><span className="bold prop">name:</span> This value is for all the radio buttons belongs to the same group | string </p>
-                            <p><span className="bold prop">classes:</span> costum classes that can be added to the component | string </p>
+                            <p><span className="bold prop">classes:</span> custom classes that can be added to the component | string </p>
                             <p><span className="bold prop">disabled:</span> Option of disable the radio button | boolean</p>
                             <p><span className="bold prop">required:</span> Option of required for form validation | boolean</p>
                             <p><span className="bold prop">options:</span> The options of the select element | array</p>

--- a/src/views/TabsPage.js
+++ b/src/views/TabsPage.js
@@ -57,7 +57,7 @@ class TabsPage extends React.Component{
                         <h2>Component props</h2>
                         <p><span className="bold prop">tabs:</span> the names of the tabs | array </p>
                         <p><span className="bold prop">activeTabs:</span> the index number of the tabs(from the arrat) that should be active on load | number</p>
-                        <p><span className="bold prop">classes:</span> costum classes that can be added to the component | string </p>
+                        <p><span className="bold prop">classes:</span> custom classes that can be added to the component | string </p>
                         <p><span className="bold prop">id:</span> Special id for element cathing with js | string </p>
                     </div>
                 </div>

--- a/src/views/TextboxPage.js
+++ b/src/views/TextboxPage.js
@@ -160,7 +160,7 @@ class TextboxPage extends React.Component{
                             <p><span className="bold prop">rows:</span> Set the number of visual rows of the Textbox | number / string </p>
                             <p><span className="bold prop">cols:</span> Set the number of visual cols of the Textbox | number / string </p>
                             <p><span className="bold prop">maxlength:</span> Set the maximum characters that user can insert | number / string </p>
-                            <p><span className="bold prop">classes:</span> costum classes that can be added to the component | string </p>
+                            <p><span className="bold prop">classes:</span> custom classes that can be added to the component | string </p>
                             <p><span className="bold prop">placeholder: </span> A placeholder that will shown as default value in input. | string </p>
                             <p><span className="bold prop">error:</span> The error message that appears when there is an error | string </p>
                             <p><span className="bold prop">note:</span> The note that that appears to give a direction for user| string </p>                            

--- a/src/views/ToasterPage.js
+++ b/src/views/ToasterPage.js
@@ -95,7 +95,7 @@ class ToasterPage extends React.Component{
                             {/* props options */}
                             <h2>Component props </h2>
                             <p><span className="bold prop">type:</span> The type of the toaster notice - success,error,info,warning | string</p>
-                            <p><span className="bold prop">classes:</span> costum classes that can be added to the component | string </p>
+                            <p><span className="bold prop">classes:</span> custom classes that can be added to the component | string </p>
                             <p><span className="bold prop">id:</span> Special id for element cathing with js | string </p>
                             <p><span className="bold prop">position:</span> The corner which in it the toaster will pop | string</p>
                             <p><span className="bold prop">title:</span> The title of the toaster | string</p>

--- a/src/views/ToggleButtonPage.js
+++ b/src/views/ToggleButtonPage.js
@@ -133,7 +133,7 @@ class ToggleButtonPage extends React.Component{
                             <p><span className="bold prop">label:</span> The text that will be written aside the Textbox | string</p>
                             <p><span className="bold prop">name:</span> This value is for form submit purpse | string </p>
                             <p><span className="bold prop">value:</span> The value that will be transfer as the user selection when click on this option | string </p>
-                            <p><span className="bold prop">classes:</span> costum classes that can be added to the component | string </p>
+                            <p><span className="bold prop">classes:</span> custom classes that can be added to the component | string </p>
                             <p><span className="bold prop">id:</span> Special id for element cathing with js | string </p>
                             <p><span className="bold prop">isChecked:</span> Set the radio button state - chosen ir not | boolean</p>
                             <p><span className="bold prop">disabled:</span> Option of disable the Textbox | boolean</p>


### PR DESCRIPTION
## Summary
- fix typo 'costum classes' across documentation in `src/views`

## Testing
- `npm test --silent -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68865134fa808325bfdcf93916ec2194