### PR TITLE
Fix ToasterPage props mapping

### DIFF
--- a/src/views/ToasterPage.js
+++ b/src/views/ToasterPage.js
@@ -13,14 +13,14 @@ class ToasterPage extends React.Component{
         tabs: ['toaster'],
         activeTab: 0,
         toasterStatus: false,
-        showToaster: this.props.showToaster,
+        showToaster: this.props.toasterSettings.showToaster,
     }
 
     //functions
     static getDerivedStateFromProps(props) {
         return {
-            toasterStatus:props.toasterStatus,
-            showToaster:props.showToaster
+            toasterStatus: props.toasterSettings.toasterStatus,
+            showToaster: props.toasterSettings.showToaster
         }
     }
 
@@ -153,7 +153,7 @@ class ToasterPage extends React.Component{
 }
 
 const mapStateToProps = (state) =>{
-    return {setToaster: state.setToaster}
+    return { toasterSettings: state.toasterSettings }
 }
 
 export default connect(mapStateToProps,{setToaster})(ToasterPage);


### PR DESCRIPTION
## Summary
- connect ToasterPage to Redux toaster settings
- update component to use `props.toasterSettings`

## Testing
- `CI=true npm test --silent -- -w=0`

------
https://chatgpt.com/codex/tasks/task_e_6888d090b7a08325bc32c2a3601e297e