### PR TITLE
Fix entrance page dark mode

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -7,7 +7,7 @@ import { connect } from 'react-redux';
 import { setModal, setToaster } from './../actions';
 
 // Import routes components
-import Entrace from './../views/Entrace';
+import Entrance from './../views/Entrance';
 import IconPage from './../views/IconPage';
 import ButtonPage from './../views/ButtonPage';
 import RadioPage from './../views/RadioPage';
@@ -83,10 +83,10 @@ class App extends React.Component  {
         theme === 'dark' ? this.setState({darkTheme: true}) : this.setState({darkTheme: false});
         html.classList.add(theme);
 
-        //opener only appears on entrace page
+        // opener only appears on entrance page
         let location = window.location.href;
-        let onEntracePage = location.indexOf('Page') === -1 ? true : false;
-        if(onEntracePage){this.setState({openerState:true})};
+        let onEntrancePage = location.indexOf('Page') === -1 ? true : false;
+        if(onEntrancePage){this.setState({openerState:true})};
     }
 
     opener = () => {
@@ -188,9 +188,9 @@ class App extends React.Component  {
 
                     {/*Components explanations area*/}
                     <div className="components-info">
-                        <Route path="/" exact 
+                        <Route path="/" exact
                             render={(props) => (
-                                <Entrace {...props} theme={this.state.darkTheme}/>
+                                <Entrance {...props} theme={this.state.darkTheme}/>
                             )}
                         ></Route>
                         <Route path="/ButtonPage" component={ButtonPage}></Route>

--- a/src/components/SideBar.js
+++ b/src/components/SideBar.js
@@ -57,7 +57,7 @@ class SideBar extends React.Component{
                     </div>
                 </Link>
                 <ul className="components-list" ref={this.tabsList}>
-                    <li className="item active"><Link to="/" onClick={(e) => this.changeRoute(e)}>Entrace</Link></li>
+                    <li className="item active"><Link to="/" onClick={(e) => this.changeRoute(e)}>Entrance</Link></li>
                     <hr className={"separator-vertical"}></hr>
                     <li className="item"><Link to="/ButtonPage" onClick={(e) => this.changeRoute(e)}>Button</Link></li>
                     <li className="item"><Link to="/IconPage" onClick={(e) => this.changeRoute(e)}>Icon</Link></li>

--- a/src/styles/_general.scss
+++ b/src/styles/_general.scss
@@ -3,7 +3,7 @@
 /********************/
 
 html{
-    height: auto;
+    height: 100%;
 
     &.no-scroll{
         overflow: hidden;
@@ -17,8 +17,13 @@ html{
 
 body{
     @include c($grayscale-level-1);
+    @include bg($grayscale-level-1);
+    height: 100%;
 
-
+    // dark mode
+    .dark & {
+        @include bg($grayscale-level-9);
+    }
 }
 
 

--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -27,7 +27,7 @@
 
 /* views */
 @import './pages-styles/_home-page.scss';
-@import './pages-styles/_entrace';
+@import './pages-styles/_entrance';
 @import './pages-styles/_button-page.scss';
 @import './pages-styles/_icon-page.scss';
 @import './pages-styles/_checkbox-page.scss';

--- a/src/styles/pages-styles/_entrance.scss
+++ b/src/styles/pages-styles/_entrance.scss
@@ -1,8 +1,9 @@
+
 /**************/
-/** entrace */
+/** entrance */
 /**************/
 
-.entrace{
+.entrance{
     .main-img{
         position: absolute;
         right: 0;
@@ -48,7 +49,7 @@
 
 /* spesific break point */
 @media (max-width: 975px) and (min-width: 500px){
-    .entrace{
+    .entrance{
         .main-img{
             @include hide();
         }
@@ -61,7 +62,7 @@
 
 /* mobile */
 @media screen and (max-width: 500px){
-    .entrace{
+    .entrance{
         height: 100vh;
             
         .main-img{

--- a/src/views/Entrance.js
+++ b/src/views/Entrance.js
@@ -3,9 +3,9 @@ import React from 'react';
 //import components
 import Img from '../components/Img';
 
-const Entrace = (props) =>{
+const Entrance = (props) =>{
     return (
-        <div className="ui container entrace">
+        <div className="ui container entrance">
             <div className="grid">
 
                 <div className="row mr-b-md">
@@ -43,4 +43,4 @@ const Entrace = (props) =>{
     );
 };
 
-export default Entrace;
+export default Entrance;


### PR DESCRIPTION
## Summary
- rename `Entrace` page to `Entrance`
- update imports and sidebar text
- set html and body height to 100% and add dark background color

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6889d84439e883258e43a23d0aa6864f