### PR TITLE
refactor: convert InputField to functional component

### DIFF
--- a/src/components/InputField.js
+++ b/src/components/InputField.js
@@ -1,143 +1,110 @@
 import React from 'react';
 
+const InputField = ({
+  label = '',
+  type = 'text',
+  id = undefined,
+  classes = '',
+  name = '',
+  min = undefined,
+  max = undefined,
+  minlength = undefined,
+  maxlength = 30,
+  pattern = undefined,
+  autocomplete = 'off',
+  required = false,
+  disabled = false,
+  placeholder = undefined,
+  error = 'This field is required',
+  showError = false,
+  note = undefined,
+  value = undefined,
+  onBlur,
+  change,
+}) => {
+  const charIsUse = value ? value.length : 0;
 
-class InputField extends React.Component{
+  const handleBlur = event => {
+    if (onBlur) {
+      onBlur(event.target);
+    }
+  };
 
-    state = {
-        label:this.props.label,
-        type:this.props.type,
-        id:this.props.id,
-        classes:this.props.classes,
-        name:this.props.name,
-        min:this.props.min,
-        max:this.props.max,
-        minlength:this.props.minlength,
-        maxlength:this.props.maxlength,
-        pattern:this.props.pattern,
-        autocomplete:this.props.autocomplete,
-        required:this.props.required,
-        disabled:this.props.disabled,
-        placeholder:this.props.placeholder,
-        error: '',
-        note: this.props.note,
-        value: this.props.value,
-        showError: true,
-        charIsUse: this.props.value ? this.props.value.length : 0
+  const handleChange = e => {
+    if (pattern) {
+      const reg = new RegExp(pattern);
+      if (!reg.test(e.target.value)) {
+        return;
+      }
     }
 
-    static getDerivedStateFromProps(props) {
-        return {
-            label: props.label,
-            type: props.type,
-            id: props.id,
-            classes: props.classes,
-            name: props.name,
-            min: props.min,
-            max: props.max,
-            minlength: props.minlength,
-            maxlength: props.maxlength,
-            pattern: props.pattern,
-            autocomplete: props.autocomplete,
-            required: props.required,
-            disabled: props.disabled,
-            value: props.value,
-            error: props.error,
-            note: props.note,
-            placeholder: props.placeholder,
-            showError: props.showError,
-            charIsUse: props.value ? props.value.length : 0
-        }
+    if (change) {
+      change(e.target.value);
     }
+  };
 
-    onBlur = event =>{
-        if(this.props.onBlur){
-            this.props.onBlur(event.target)
-        }
-    }
-
-    change = (e) =>{
-        if(this.state.pattern){
-            let pattern = new RegExp(this.state.pattern);
-            if(!pattern.test(e.target.value)){
-                return
-            }
-        }
-
-        if(this.props.change){
-            this.props.change(e.target.value)
-        }
-        
-    }
-
-    render(){ 
-
-        return (
-            <div className={`input-field ${this.state.placeholder ? "placeholder":""} ${this.state.value ? "with-value" : "" }`}>
-                <label className={`field`}>
-                    <input 
-                        type={this.state.type} 
-                        id={this.state.id}
-                        classes={this.state.classes}
-                        name={this.state.name} 
-                        min={this.state.min}
-                        max={this.state.max}
-                        minLength={this.state.minlength}
-                        maxLength={this.state.maxlength}
-                        pattern={this.state.pattern}
-                        required={this.state.required}
-                        disabled={this.state.disabled} 
-                        autoComplete={this.state.autocomplete}
-                        placeholder={this.state.placeholder}
-                        onBlur={this.onBlur}
-                        value={this.state.value} 
-                        onChange={this.change}
-                        showerror={this.state.showError.toString()}
-                    />
-                    <span className="label">
-                        {this.state.label}{(this.state.required) ? <span className="astrix">*</span> : null }
-                        </span>
-                </label>
-                <div className="helpers">
-                    {
-                        (this.state.error && this.state.showError && this.state.required)
-                        ?
-                        <span className="error">{this.state.error}</span>
-                        :
-                        null
-                    }
-                    {
-                        (this.state.note && !this.state.showError)
-                        ?
-                        <span className="note">{this.state.note}</span>
-                        :
-                        null
-                    }
-                    <span className="char-num">{this.state.charIsUse}/{this.state.maxlength}</span>
-                </div>
-            </div>
-        );
-    }
-}
-
-InputField.defaultProps = {
-    label:'',
-    type:'text',
-    id:undefined,
-    classes:'',
-    name:'',
-    min:undefined,
-    max:undefined,
-    minlength:undefined,
-    maxlength:30,
-    pattern:undefined,
-    autocomplete:'off',
-    required:false,
-    disabled:false,
-    placeholder:undefined,
-    error:'This field is required',
-    showError: false,
-    note:undefined,
-    value:undefined
-}
+  return (
+    <div
+      className={`input-field ${placeholder ? 'placeholder' : ''} ${
+        value ? 'with-value' : ''
+      }`}
+    >
+      <label className={`field`}>
+        <input
+          type={type}
+          id={id}
+          classes={classes}
+          name={name}
+          min={min}
+          max={max}
+          minLength={minlength}
+          maxLength={maxlength}
+          pattern={pattern}
+          required={required}
+          disabled={disabled}
+          autoComplete={autocomplete}
+          placeholder={placeholder}
+          onBlur={handleBlur}
+          value={value}
+          onChange={handleChange}
+          showerror={showError.toString()}
+        />
+        <span className="label">
+          {label}
+          {required ? <span className="astrix">*</span> : null}
+        </span>
+      </label>
+      <div className="helpers">
+        {error && showError && required ? (
+          <span className="error">{error}</span>
+        ) : null}
+        {note && !showError ? <span className="note">{note}</span> : null}
+        <span className="char-num">{charIsUse}/{maxlength}</span>
+      </div>
+    </div>
+  );
+};
 
 export default InputField;
+
+InputField.defaultProps = {
+  label: '',
+  type: 'text',
+  id: undefined,
+  classes: '',
+  name: '',
+  min: undefined,
+  max: undefined,
+  minlength: undefined,
+  maxlength: 30,
+  pattern: undefined,
+  autocomplete: 'off',
+  required: false,
+  disabled: false,
+  placeholder: undefined,
+  error: 'This field is required',
+  showError: false,
+  note: undefined,
+  value: undefined,
+};
+


### PR DESCRIPTION
## Summary
- refactor InputField to use a functional component with hooks

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_6891d1b2bffc8325b6ec3c793d9ae007